### PR TITLE
Add server identity to known_hosts if missing

### DIFF
--- a/prodaccess_nix.go
+++ b/prodaccess_nix.go
@@ -10,18 +10,19 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"path"
+	"os/user"
 	"strings"
-
-	"golang.org/x/sys/unix"
 )
 
 var (
 	sshPubKey       = flag.String("sshpubkey", "$HOME/.ssh/id_ecdsa.pub", "SSH public key to request signed")
 	sshCert         = flag.String("sshcert", "$HOME/.ssh/id_ecdsa-cert.pub", "SSH certificate to write")
+	sshKnownHosts   = flag.String("sshknownhosts", "$HOME/.ssh/known_hosts", "SSH known hosts file to use")
 	vaultTokenPath  = flag.String("vault_token", "$HOME/.vault-token", "Path to Vault token to update")
 	vmwareCertPath  = flag.String("vmware_cert_path", "$HOME/vmware-user.pfx", "Path to store VMware user certificate")
 	browserCertPath = flag.String("browser_cert_path", "$HOME/browser-user.pfx", "Path to store Browswer user certificate")
+
+	certAuthority = "@cert-authority *.event.dreamhack.se ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1MjEAAACFBAC/xT7a8A4Gm1Tf0mpKstqncWsOZpGPKa0lqf7EuYSpWUnx5QLaiP2TcI80AELTw2gP9jzOkpN7/QO91V3edRXGLAGk3NiNZLqvJspYfAnEo9f3/E4GBZf4kcDC93+04SzbFg+qMY3iCmJNaIttUMdQwaR22c+HbOYhaGEFWN3OCa6Erw== vault@tech.dreamhack.se"
 )
 
 func sshLoadCertificate(c string) {
@@ -29,6 +30,32 @@ func sshLoadCertificate(c string) {
 	err := ioutil.WriteFile(cp, []byte(c), 0644)
 	if err != nil {
 		log.Printf("failed to write SSH certificate: %v", err)
+	}
+
+	// Add cert authority to known_hosts
+	usr, err := user.Current()
+	if err != nil {
+		log.Printf("failed to get homedir: %v", err)
+	} else {
+		path := strings.Replace(*sshKnownHosts, "$HOME", usr.HomeDir, 1)
+		kh, err := ioutil.ReadFile(path)
+		if err != nil {
+			log.Printf("failed to read SSH known hosts: %v", err)
+		} else {
+			if !strings.Contains(string(kh), certAuthority) {
+				log.Printf("adding server identity to SSH known hosts")
+				f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0600)
+				if err != nil {
+					log.Printf("failed to open SSH known hosts file for writing: %v", err)
+				}
+				defer f.Close()
+				if _, err = f.WriteString(certAuthority); err != nil {
+					log.Printf("failed to write to SSH known hosts file: %v", err)
+				}
+			} else {
+				log.Printf("skipping SSH known hosts, already exists")
+			}
+		}
 	}
 
 	// OpenSSH requires adding the private key again to load certificates
@@ -87,23 +114,27 @@ func saveVmwareCertificate(c string, k string) {
 	kf.Write([]byte(k))
 	cp := cf.Name()
 	kp := kf.Name()
-	defer os.Remove(cp)
-	defer os.Remove(kp)
-	cf.Close()
 	cf.Close()
 	kf.Close()
 
 	fp := os.ExpandEnv(*vmwareCertPath)
 	os.Remove(fp)
 	os.OpenFile(fp, os.O_CREATE, 0600)
+	cmd := exec.Command("/usr/bin/env", "openssl", "pkcs12", "-export", "-password", "pass:",
+		"-in", cp, "-inkey", kp, "-out", fp)
 
-	_, _ = executeWithStdout("openssl", "pkcs12", "-export", "-password", "pass:", "-in", cp, "-inkey", kp, "-out", fp)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
 
-	if isWSL() {
-		if err := importCertFromWSL(fp); err != nil {
-			log.Printf("Failed to import certificate: %v", err)
-		}
+	err := cmd.Run()
+	if err != nil {
+		log.Printf("Failed to emit VMware certificate: %v", err)
+		log.Printf("Standard output: %s", stdout.String())
+		log.Printf("Error output: %s", stderr.String())
 	}
+	os.Remove(cp)
+	os.Remove(kp)
 }
 
 func saveBrowserCertificate(c string, k string) {
@@ -113,89 +144,25 @@ func saveBrowserCertificate(c string, k string) {
 	kf.Write([]byte(k))
 	cp := cf.Name()
 	kp := kf.Name()
-	defer os.Remove(cp)
-	defer os.Remove(kp)
 	cf.Close()
 	kf.Close()
 
 	fp := os.ExpandEnv(*browserCertPath)
 	os.Remove(fp)
 	os.OpenFile(fp, os.O_CREATE, 0600)
-	_, _ = executeWithStdout("openssl", "pkcs12", "-export", "-password", "pass:", "-in", cp, "-inkey", kp, "-out", fp)
+	cmd := exec.Command("/usr/bin/env", "openssl", "pkcs12", "-export", "-password", "pass:",
+		"-in", cp, "-inkey", kp, "-out", fp)
 
-	if isWSL() {
-		if err := importCertFromWSL(fp); err != nil {
-			log.Printf("Failed to import certificate: %v", err)
-		}
-	}
-}
-
-func isWSL() bool {
-	u := unix.Utsname{}
-	_ = unix.Uname(&u)
-	return strings.Contains(string(u.Release[:]), "Microsoft")
-}
-
-func executeWithStdout(cmd ...string) (string, error) {
-	return executeWithStdoutWithStdin("", cmd...)
-}
-
-func executeWithStdoutWithStdin(stdin string, cmd ...string) (string, error) {
-	c := exec.Command("/usr/bin/env", cmd...)
 	var stdout, stderr bytes.Buffer
-	si := bytes.NewBufferString(stdin)
-	c.Stdout = &stdout
-	c.Stderr = &stderr
-	c.Stdin = si
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
 
-	err := c.Run()
+	err := cmd.Run()
 	if err != nil {
-		log.Printf("Failed to execute %v: %v", cmd, err)
+		log.Printf("Failed to emit Browser certificate: %v", err)
 		log.Printf("Standard output: %s", stdout.String())
 		log.Printf("Error output: %s", stderr.String())
-		return "", err
 	}
-
-	return stdout.String(), nil
-}
-
-func executeWithStdin(stdin string, cmd ...string) error {
-	_, err := executeWithStdoutWithStdin(stdin, cmd...)
-	return err
-}
-
-// If running under WSL invoke PowerShell to import certificate
-func importCertFromWSL(pfx string) error {
-	winpath, err := executeWithStdout("powershell.exe", "echo $env:TEMP")
-	if err != nil {
-		return err
-	}
-
-	winpath = strings.Trim(winpath, "\r\n")
-	winparts := strings.Split(winpath, "\\")
-	drive := strings.ToLower(winparts[0][:1])
-	winparts = winparts[1:]
-	temppath := path.Join("/mnt", drive, path.Join(winparts...), "prodaccess.pfx")
-
-	pfxdata, err := ioutil.ReadFile(pfx)
-	if err != nil {
-		return err
-	}
-
-	err = ioutil.WriteFile(temppath, pfxdata, 0644)
-	if err != nil {
-		return err
-	}
-	defer os.Remove(temppath)
-
-	ps := fmt.Sprintf(psImport, winpath+"\\prodaccess.pfx")
-	fmt.Printf("%s\n", ps)
-	o, err := executeWithStdoutWithStdin(ps, "powershell.exe", "-Command", "-")
-	if err != nil {
-		return err
-	}
-
-	log.Printf("Imported certificate: %s", o)
-
-	return executeWithStdin(psPurge, "powershell.exe", "-Command", "-")
+	os.Remove(cp)
+	os.Remove(kp)
 }


### PR DESCRIPTION
This will add the event servers identity to known_hosts if it is missing when running prodaccess